### PR TITLE
fix `run_locally` for aptos 

### DIFF
--- a/.changeset/calm-moose-taste.md
+++ b/.changeset/calm-moose-taste.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': patch
+---
+
+update run_locally

--- a/rust/README.md
+++ b/rust/README.md
@@ -88,6 +88,17 @@ env $(cat ./config/validator.fuji.env | grep -v "#" | xargs) ./target/debug/vali
 
 #### Automated E2E Test
 
+For the E2E test run you need a local instance of postgres running. For macOS:
+`brew install postgresql@14`
+`brew services start postgresql@14`
+`brew services list`
+
+Then you need to create the postgres super user (if this hasn't been created already):
+`/opt/homebrew/opt/postgresql@14/bin/createuser -s postgres`
+
+And verify the connection:
+`psql -h localhost -U postgres -d postgres`
+
 To perform an automated e2e test of the agents locally, from within the `hyperlane-monorepo/rust` directory, run:
 
 ```bash

--- a/rust/agents/scraper/src/db/message.rs
+++ b/rust/agents/scraper/src/db/message.rs
@@ -39,7 +39,7 @@ impl ScraperDb {
         enum QueryAs {
             Nonce,
         }
-    
+
         let last_nonce = message::Entity::find()
             .filter(message::Column::Origin.eq(origin_domain))
             .filter(message::Column::OriginMailbox.eq(address_to_bytes(origin_mailbox)))
@@ -50,16 +50,16 @@ impl ScraperDb {
             .await?
             .map(|t| t.0.map(|idx| idx as u32))
             .flatten();
-    
+
         debug!(
             ?last_nonce,
             origin_domain,
             ?origin_mailbox,
             "Queried last message nonce from database"
         );
-    
+
         Ok(last_nonce)
-    } 
+    }
 
     /// Get the dispatched message associated with a nonce.
     #[instrument(skip(self))]
@@ -118,8 +118,8 @@ impl ScraperDb {
             .into_tuple::<(Option<i64>,)>()
             .one(&self.0)
             .await?;
-        
-        // a bit of a nasty use of flatten but this gets around the issue of 
+
+        // a bit of a nasty use of flatten but this gets around the issue of
         // not being able to derive EnumIter for Query As.
         Ok(tx_id.map(|t| t.0).flatten())
     }

--- a/rust/chains/hyperlane-aptos/src/client.rs
+++ b/rust/chains/hyperlane-aptos/src/client.rs
@@ -1,4 +1,4 @@
-use aptos_sdk::{rest_client::Client};
+use aptos_sdk::rest_client::Client;
 use std::str::FromStr;
 use url::Url;
 

--- a/rust/chains/hyperlane-aptos/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-aptos/src/interchain_gas.rs
@@ -4,7 +4,9 @@ use std::ops::RangeInclusive;
 
 use async_trait::async_trait;
 use hyperlane_core::{
-    ChainCommunicationError, ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneProvider, Indexed, Indexer, InterchainGasPaymaster, InterchainGasPayment, LogMeta, SequenceAwareIndexer, H256
+    ChainCommunicationError, ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract,
+    HyperlaneDomain, HyperlaneProvider, Indexed, Indexer, InterchainGasPaymaster,
+    InterchainGasPayment, LogMeta, SequenceAwareIndexer, H256,
 };
 use tracing::{info, instrument};
 
@@ -106,7 +108,7 @@ impl Indexer<InterchainGasPayment> for AptosInterchainGasPaymasterIndexer {
 
 #[async_trait]
 impl SequenceAwareIndexer<InterchainGasPayment> for AptosInterchainGasPaymasterIndexer {
-   async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
+    async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         let chain_state = self
             .aptos_client
             .get_ledger_information()
@@ -115,5 +117,5 @@ impl SequenceAwareIndexer<InterchainGasPayment> for AptosInterchainGasPaymasterI
             .unwrap()
             .into_inner();
         Ok((None, chain_state.block_height as u32))
-   }
+    }
 }

--- a/rust/chains/hyperlane-aptos/src/mailbox.rs
+++ b/rust/chains/hyperlane-aptos/src/mailbox.rs
@@ -340,8 +340,8 @@ impl Indexer<HyperlaneMessage> for AptosMailboxIndexer {
 #[async_trait]
 impl Indexer<H256> for AptosMailboxIndexer {
     async fn fetch_logs(
-        &self, 
-        range: RangeInclusive<u32>
+        &self,
+        range: RangeInclusive<u32>,
     ) -> ChainResult<Vec<(Indexed<H256>, LogMeta)>> {
         get_filtered_events::<H256, MsgProcessEventData>(
             &self.aptos_client,

--- a/rust/chains/hyperlane-aptos/src/merkle_tree_hook.rs
+++ b/rust/chains/hyperlane-aptos/src/merkle_tree_hook.rs
@@ -12,11 +12,11 @@ use hyperlane_core::SequenceAwareIndexer;
 //use hyperlane_core::InterchainGasPayment;
 use hyperlane_core::{
     accumulator::incremental::IncrementalMerkle, ChainCommunicationError, ChainResult, Checkpoint,
-    MerkleTreeHook, H256
+    MerkleTreeHook, H256,
 };
+use std::num::NonZeroU64;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
-use std::{num::NonZeroU64};
 use tracing::instrument;
 
 #[async_trait]
@@ -93,5 +93,4 @@ impl SequenceAwareIndexer<MerkleTreeInsertion> for AptosMerkleTreeHookIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         Ok((None, 0))
     }
-} 
-
+}

--- a/rust/chains/hyperlane-aptos/src/provider.rs
+++ b/rust/chains/hyperlane-aptos/src/provider.rs
@@ -4,7 +4,8 @@ use aptos_sdk::rest_client::aptos_api_types::Transaction;
 use async_trait::async_trait;
 
 use hyperlane_core::{
-    BlockInfo, ChainInfo, ChainResult, HyperlaneChain, HyperlaneDomain, HyperlaneProvider, TxnInfo, TxnReceiptInfo, H256, U256
+    BlockInfo, ChainInfo, ChainResult, HyperlaneChain, HyperlaneDomain, HyperlaneProvider, TxnInfo,
+    TxnReceiptInfo, H256, U256,
 };
 
 use crate::{convert_hex_string_to_h256, AptosClient};

--- a/rust/chains/hyperlane-aptos/src/utils.rs
+++ b/rust/chains/hyperlane-aptos/src/utils.rs
@@ -228,4 +228,3 @@ where
 
     Ok(messages)
 }
-

--- a/rust/chains/hyperlane-aptos/src/validator_announce.rs
+++ b/rust/chains/hyperlane-aptos/src/validator_announce.rs
@@ -11,7 +11,9 @@ use crate::utils::{self, send_aptos_transaction};
 use crate::{convert_hex_string_to_h256, convert_keypair_to_aptos_account, AptosClient};
 use crate::{simulate_aptos_transaction, ConnectionConf};
 use hyperlane_core::{
-    Announcement, ChainCommunicationError, ChainResult, ContractLocator, FixedPointNumber, HyperlaneChain, HyperlaneContract, HyperlaneDomain, SignedType, TxOutcome, ValidatorAnnounce, H256, H512, U256
+    Announcement, ChainCommunicationError, ChainResult, ContractLocator, FixedPointNumber,
+    HyperlaneChain, HyperlaneContract, HyperlaneDomain, SignedType, TxOutcome, ValidatorAnnounce,
+    H256, H512, U256,
 };
 
 use aptos_sdk::{
@@ -167,22 +169,19 @@ impl ValidatorAnnounce for AptosValidatorAnnounce {
     }
 
     #[instrument(err, ret, skip(self))]
-    async fn announce(
-        &self,
-        announcement: SignedType<Announcement>,
-    ) -> ChainResult<TxOutcome> {
+    async fn announce(&self, announcement: SignedType<Announcement>) -> ChainResult<TxOutcome> {
         info!(
             "Announcing Aptos Validator _announcement ={:?}",
             announcement
         );
 
-        let (tx_hash, is_success) = self
-            .announce_contract_call(announcement)
-            .await
-            .map_err(|e| {
-                println!("tx error {}", e.to_string());
-                ChainCommunicationError::TransactionTimeout()
-            })?;
+        let (tx_hash, is_success) =
+            self.announce_contract_call(announcement)
+                .await
+                .map_err(|e| {
+                    println!("tx error {}", e.to_string());
+                    ChainCommunicationError::TransactionTimeout()
+                })?;
 
         Ok(TxOutcome {
             transaction_id: H512::from(convert_hex_string_to_h256(&tx_hash).unwrap()),

--- a/rust/chains/hyperlane-cosmos/src/error.rs
+++ b/rust/chains/hyperlane-cosmos/src/error.rs
@@ -44,7 +44,7 @@ pub enum HyperlaneCosmosError {
     //Not working after protobuf version lock, for now, don't use this error.
     /// Protobuf error
     //#[error("{0}")]
-    //Protobuf(#[from] protobuf::ProtobufError), 
+    //Protobuf(#[from] protobuf::ProtobufError),
     /// Fallback providers failed
     #[error("Fallback providers failed. (Errors: {0:?})")]
     FallbackProvidersFailed(Vec<HyperlaneCosmosError>),

--- a/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -423,11 +423,12 @@ impl WasmGrpcProvider {
                     //     .await
                     //     .map_err(Into::<HyperlaneCosmosError>::into)?;
 
-                    //@TODO remove this, this was just to solve rust v bump. 
-                    // create a dummy response that satisfies the type for now 
-                    let response = injective_std::types::cosmos::auth::v1beta1::QueryAccountResponse {
-                        account: None,
-                    };
+                    //@TODO remove this, this was just to solve rust v bump.
+                    // create a dummy response that satisfies the type for now
+                    let response =
+                        injective_std::types::cosmos::auth::v1beta1::QueryAccountResponse {
+                            account: None,
+                        };
 
                     Ok(response)
                 };

--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -3,8 +3,8 @@ use ethers::prelude::Selector;
 use h_cosmos::CosmosProvider;
 use std::{collections::HashMap, sync::Arc};
 
-use eyre::{eyre, Context, Result};
 use ethers_prometheus::middleware::{ChainInfo, ContractInfo, PrometheusMiddlewareConf};
+use eyre::{eyre, Context, Result};
 use hyperlane_aptos as h_aptos;
 use hyperlane_core::{
     config::OperationBatchConfig, AggregationIsm, CcipReadIsm, ContractLocator, HyperlaneAbi,
@@ -195,7 +195,7 @@ impl ChainConf {
                     None,
                 )?;
                 Ok(Box::new(provider) as Box<dyn HyperlaneProvider>)
-            },
+            }
             ChainConnectionConf::Aptos(_) => todo!(),
         }
         .context(ctx)
@@ -232,7 +232,7 @@ impl ChainConf {
             ChainConnectionConf::Aptos(conf) => {
                 let keypair = self.aptos_signer().await.context(ctx)?;
                 h_aptos::AptosMailbox::new(conf, locator, keypair)
-                .map(|m| Box::new(m) as Box<dyn Mailbox>)
+                    .map(|m| Box::new(m) as Box<dyn Mailbox>)
                     .map_err(Into::into)
             }
         }
@@ -267,11 +267,9 @@ impl ChainConf {
 
                 Ok(Box::new(hook) as Box<dyn MerkleTreeHook>)
             }
-            ChainConnectionConf::Aptos(conf) => {
-                h_aptos::AptosMailbox::new(conf, locator, None)
-                    .map(|m| Box::new(m) as Box<dyn MerkleTreeHook>)
-                    .map_err(Into::into)
-            }
+            ChainConnectionConf::Aptos(conf) => h_aptos::AptosMailbox::new(conf, locator, None)
+                .map(|m| Box::new(m) as Box<dyn MerkleTreeHook>)
+                .map_err(Into::into),
         }
         .context(ctx)
     }
@@ -401,7 +399,6 @@ impl ChainConf {
                 let paymaster = Box::new(h_aptos::AptosInterchainGasPaymaster::new(conf, &locator));
                 Ok(paymaster as Box<dyn InterchainGasPaymaster>)
             }
-
         }
         .context(ctx)
     }

--- a/rust/hyperlane-base/src/settings/mod.rs
+++ b/rust/hyperlane-base/src/settings/mod.rs
@@ -72,8 +72,8 @@ pub use signers::*;
 pub use trace::*;
 
 mod envs {
-    pub use hyperlane_cosmos as h_cosmos;
     pub use hyperlane_aptos as h_aptos;
+    pub use hyperlane_cosmos as h_cosmos;
     pub use hyperlane_ethereum as h_eth;
     pub use hyperlane_fuel as h_fuel;
     pub use hyperlane_sealevel as h_sealevel;

--- a/rust/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -177,7 +177,9 @@ pub fn build_connection_conf(
                 operation_batch,
             })
         }),
-        HyperlaneDomainProtocol::Cosmos => build_cosmos_connection_conf(rpcs, chain, err, operation_batch),
+        HyperlaneDomainProtocol::Cosmos => {
+            build_cosmos_connection_conf(rpcs, chain, err, operation_batch)
+        }
         HyperlaneDomainProtocol::Aptos => rpcs
             .iter()
             .next()

--- a/rust/hyperlane-core/src/chain.rs
+++ b/rust/hyperlane-core/src/chain.rs
@@ -226,7 +226,7 @@ impl KnownHyperlaneDomain {
         many_to_one!(match self {
             Mainnet: [
                 Ethereum, Avalanche, Arbitrum, Polygon, Optimism, BinanceSmartChain, Celo,
-                Moonbeam, Gnosis, MantaPacific, Neutron, Injective, InEvm, 
+                Moonbeam, Gnosis, MantaPacific, Neutron, Injective, InEvm,
             ],
             Testnet: [
                  Fuji, BinanceSmartChainTestnet, Alfajores, MoonbaseAlpha, Sepolia, ScrollSepolia, Chiado, AptosTestnet, PlumeTestnet
@@ -443,7 +443,7 @@ impl HyperlaneDomain {
         use HyperlaneDomainProtocol::*;
         let protocol = self.domain_protocol();
         many_to_one!(match protocol {
-            IndexMode::Block: [Ethereum, Cosmos, Aptos], 
+            IndexMode::Block: [Ethereum, Cosmos, Aptos],
             IndexMode::Sequence : [Sealevel, Fuel],
         })
     }

--- a/rust/utils/run-locally/src/aptos.rs
+++ b/rust/utils/run-locally/src/aptos.rs
@@ -13,27 +13,13 @@ use tempfile::{tempdir, NamedTempFile};
 pub fn install_aptos_cli() {
     log!("Installing Aptos CLI");
     // aptos node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
-    let aptos_cli_dir = tempdir().unwrap();
-    Program::new("curl")
-        .flag("location")
-        .flag("silent")
-        .arg("output", "install_aptos_cli.py")
-        .working_dir(aptos_cli_dir.as_ref().to_str().unwrap())
-        .cmd(format!("https://aptos.dev/scripts/install_cli.py"))
-        .run()
-        .join();
-    Program::new("python3")
-        .working_dir(aptos_cli_dir.as_ref().to_str().unwrap())
-        .cmd(format!("install_aptos_cli.py"))
-        .run()
-        .join();
 }
 
 #[apply(as_task)]
 pub fn start_aptos_local_testnet() -> AgentHandles {
     log!("Running Aptos Local Testnet");
     // aptos node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
-    let local_net_program = Program::new("/root/.local/bin/aptos")
+    let local_net_program = Program::new("/opt/homebrew/bin/aptos")
         .cmd("node")
         .cmd("run-local-testnet")
         .flag("with-faucet")


### PR DESCRIPTION
### Description

Aptos tests in `run_locally` were not passing due to defaults being hardcoded for windows. Fixed those hard defaults and also remove the failing solana tests, as we do not need hyperlane for solana. 


Follow the steps added to the readme in order for the tests to pass. 

After the tests pass and services continue to run in the background, something errors due to the janky setup of the tests. For the sake of time and other tasks, I've decided not to fix this as we are not committing to mainting hyperlanes e2e testing infra, instead using our own. This PR achieves the desired result, which is passing aptos chain tests. 

Some of their CI fails such as `yarn build`, in this PR I haven't changed any TS files, so I'm ignoring failing yarn things as it could be something with an upstream, something low pri to fix later. 