### PR TITLE
Fix Spelling Errors in Documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,10 +9,10 @@ This CoC applies to all members of the Hyperlane Network's community including, 
 **Code**
 
 1. Never harass or bully anyone. Not verbally, not physically, not sexually. Harassment will not be tolerated.
-2. Never discrimnate on the basis of personal characteristics or group membership.
+2. Never discriminate on the basis of personal characteristics or group membership.
 3. Treat your fellow contributors with respect, fairness, and professionalism, especially in situations of high pressure.
-4. Seek, offer, and accept objective critism of yours and others work, strive to acknowledge the contributions of others.
-5. Be transparent and honest about your qualifications and any potential conflicts of interest. Transparency is a key tenant of the Hyperlane project and we expect it from all contributors.
+4. Seek, offer, and accept objective criticism of yours and others work, strive to acknowledge the contributions of others.
+5. Be transparent and honest about your qualifications and any potential conflicts of interest. Transparency is a key tenet of the Hyperlane project and we expect it from all contributors.
 6. Bring an open and curious mind, the Hyperlane project is designed to enable developers to express their curiousity, experiment, and build things we couldn't have imagined ourselves.
 7. Stay on track - Do your best to avoid off-topic discussion and make sure you are posting to the correct channel and repositories. Distractions are costly and it is far too easy for work to go off track.
 8. Step down properly - Think of your fellow contributors when you step down from the project. Contributors of open-source projects come and go. It is crucial that when you leave the project or reduce your contribution significantly you do so in a way that minimizes disruption and keeps continuity in mind. Concretely this means telling your fellow contributors you are leaving and taking the proper steps to enable a smooth transition for other contributors to pick up where you left off.


### PR DESCRIPTION
### Fix typos:
-Fixed typo "discrimnate" → "discriminate"
-Fixed typo "critism" → "criticism"
-Fixed typo "tenant" → "tenet"